### PR TITLE
Add Input to Fail Step if Tests Fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This Action defines the following formal inputs.
 | **`gist_badge_label`**   | false | If specified, the Test Report Gist will also include an adjacent badge rendered with the status of the associated Test Report and and label content of this input.  In addition to any static text you can provide _escape tokens_ of the form `%name%` where name can be the name of any field returned from a Pester Result, such as `ExecutedAt` or `Result`.  If you want a literal percent, just specify an empty name as in `%%`.
 | **`gist_badge_message`** | false | If Gist badge generation is enabled by providing a value for the `gist_badge_label` input, this input allows you to override the default message on the badge, which is equivalent to the the Pester Result `Status` such as `Failed` or `Passed`.  As with the label input, you can specify escape tokens in addition to literal text.  See the label input description for more details.
 | **`gist_token`**         | false | GitHub OAuth/PAT token to be used for accessing Gist to store test results report. The integrated GITHUB_TOKEN that is normally accessible during a Workflow does not include read/write permissions to associated Gists, therefore a separate token is needed. You can control which account is used to actually store the state by generating a token associated with the target account.
-
+| **`tests_fail_step`**    | false | If true, will cause the step to fail if one or more tests fails.
 
 
 ### Outputs

--- a/action.ps1
+++ b/action.ps1
@@ -112,7 +112,6 @@ else {
 
     if ($inputs.tests_fail_step) {
         Write-ActionInfo "  * tests_fail_step: true"
-        $pesterConfig.Run.Exit = $true
     }
 
     $test_results_path = Join-Path $test_results_dir test-results.nunit.xml
@@ -143,6 +142,9 @@ else {
     }
     if ($error_clixml_path) {
         Set-ActionOutput -Name error_clixml_path -Value $error_clixml_path
+    }
+    if ($inputs.tests_fail_step -and ($pesterResult.FailedCount -gt 0)) {
+        $script:stepShouldFail = $true
     }
 
     Set-ActionOutput -Name result_clixml_path -Value $result_clixml_path
@@ -366,4 +368,9 @@ if ($test_results_path) {
     if ($inputs.gist_name -and $inputs.gist_token) {
         Publish-ToGist -ReportData $reportData
     }
+}
+
+if ($stepShouldFail) {
+    Write-ActionInfo "Throwing error as one or more tests failed 'tests_fail_step' was true"
+    throw "Throwing error as one or more tests failed 'tests_fail_step' was true"
 }

--- a/action.ps1
+++ b/action.ps1
@@ -40,6 +40,7 @@ $inputs = @{
     gist_token         = Get-ActionInput gist_token
     gist_badge_label   = Get-ActionInput gist_badge_label
     gist_badge_message = Get-ActionInput gist_badge_message
+    tests_fail_step    = Get-ActionInput tests_fail_step
 }
 
 $test_results_dir = Join-Path $PWD _TMP
@@ -107,6 +108,11 @@ else {
     if ($inputs.output_level) {
         Write-ActionInfo "  * output_level: $output_level"
         $pesterConfig.Output.Verbosity = $output_level
+    }
+
+    if ($inputs.tests_fail_step) {
+        Write-ActionInfo "  * tests_fail_step: true"
+        $pesterConfig.Run.Exit = $true
     }
 
     $test_results_path = Join-Path $test_results_dir test-results.nunit.xml

--- a/action.ps1
+++ b/action.ps1
@@ -371,6 +371,6 @@ if ($test_results_path) {
 }
 
 if ($stepShouldFail) {
-    Write-ActionInfo "Throwing error as one or more tests failed 'tests_fail_step' was true"
-    throw "Throwing error as one or more tests failed 'tests_fail_step' was true"
+    Write-ActionInfo "Thowing error as ne or more tests failed and 'tests_fail_step' was true."
+    throw "One or more tests failed."
 }

--- a/action.yml
+++ b/action.yml
@@ -134,8 +134,7 @@ inputs:
 
   tests_fail_step:
     description: |
-      When set to `true`, will cause the step to fail if one or more tests 
-      fails. The default is `false`.
+      If true, will cause the step to fail if one or more tests fails.
     required: false
 
 

--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,12 @@ inputs:
       You can control which account is used to actually store the state by
       generating a token associated with the target account.
 
+  tests_fail_step:
+    description: |
+      When set to `true`, will cause the step to fail if one or more tests 
+      fails. The default is `false`.
+    required: false
+
 
 ## Here you describe your *formal* outputs.
 outputs:


### PR DESCRIPTION
Hello,
I've added a new input "tests_fail_step" that will cause the step to fail if one or more test fail. I've confirmed it works as expected using one of my repos:

**tests_fail_step: true** https://github.com/natescherer/PoshEmail/actions/runs/706517341
**tests_fail_step not set** https://github.com/natescherer/PoshEmail/actions/runs/706537403

Please let me know if you have any comments/changes/etc.
