### PR TITLE
Code Coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ This Action defines the following formal inputs.
 | **`gist_badge_label`**   | false | If specified, the Test Report Gist will also include an adjacent badge rendered with the status of the associated Test Report and and label content of this input.  In addition to any static text you can provide _escape tokens_ of the form `%name%` where name can be the name of any field returned from a Pester Result, such as `ExecutedAt` or `Result`.  If you want a literal percent, just specify an empty name as in `%%`.
 | **`gist_badge_message`** | false | If Gist badge generation is enabled by providing a value for the `gist_badge_label` input, this input allows you to override the default message on the badge, which is equivalent to the the Pester Result `Status` such as `Failed` or `Passed`.  As with the label input, you can specify escape tokens in addition to literal text.  See the label input description for more details.
 | **`gist_token`**         | false | GitHub OAuth/PAT token to be used for accessing Gist to store test results report. The integrated GITHUB_TOKEN that is normally accessible during a Workflow does not include read/write permissions to associated Gists, therefore a separate token is needed. You can control which account is used to actually store the state by generating a token associated with the target account.
+| **`coverage_paths`**     | false | Comma-separated list of one or more directories to scan for code coverage, relative to the root of the project. Will include all .ps1 and .psm1 files under these directories recursively.
+| **`coverage_report_name`** | false | The name of the code coverage report object that will be attached to the Workflow Run.  Defaults to the name `COVERAGE_RESULTS_<datetime>` where `<datetime>` is in the form `yyyyMMdd_hhmmss`.
+| **`coverage_report_title`** | false | The title of the code coverage report that will be embedded in the report itself, which defaults to the same as the `code_coverage_report_name` input.
+| **`coverage_gist`**      | false | If true, will attach the coverage results to the gist specified in `gist_name`.
+| **`coverage_gist_badge`** | false | If true, render a coverage badge and add it to the gist specified in `gist_name`.
 
 
 
@@ -116,6 +121,7 @@ This Action defines the following formal outputs.
 | **`total_count`** | Total number of tests discovered.
 | **`passed_count`** | Total number of tests passed.
 | **`failed_count`** | Total number of tests failed.
+| **`coverage_results_path`** | Path to the code coverage results file in JaCoCo XML format.
 
 ### PowerShell GitHub Action
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ This Action defines the following formal inputs.
 | **`coverage_report_name`** | false | The name of the code coverage report object that will be attached to the Workflow Run.  Defaults to the name `COVERAGE_RESULTS_<datetime>` where `<datetime>` is in the form `yyyyMMdd_hhmmss`.
 | **`coverage_report_title`** | false | The title of the code coverage report that will be embedded in the report itself, which defaults to the same as the `code_coverage_report_name` input.
 | **`coverage_gist`**      | false | If true, will attach the coverage results to the gist specified in `gist_name`.
-| **`coverage_gist_badge`** | false | If true, render a coverage badge and add it to the gist specified in `gist_name`.
-
+| **`coverage_gist_badge_label`** | false | If specified, the Test Report Gist will also include an adjacent badge rendered with the percentage of the associated Coverage Report and label content of this input.
 | **`tests_fail_step`**    | false | If true, will cause the step to fail if one or more tests fails.
 
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ Check out the [usage](#usage) below.
 
 ## Samples
 
-Here we see a badge generated along with the _Gist-based_ Tests Report as part
-of a GitHub Workflow associated with this project.
+Here we see some badges generated along with links to the _Gist-based_
+Tests Report as part of a GitHub Workflow
+[associated](https://github.com/zyborg/pester-tests-report/actions/runs/298169540/workflow#L138)
+with this project.
 
-[![Example Pester Tests Badge](https://gist.github.com/ebekker/dff5ae43943226d800cd1ee891dc889b/raw/pester-tests-report_GHAction_test1.md_badge.svg)](https://gist.github.com/ebekker/dff5ae43943226d800cd1ee891dc889b)
+* [![Example Pester Tests Badge](https://gist.github.com/ebekker/9158b8c9a9999270ef482faae6f4a742/raw/pester-tests-report_Marketplace_GHAction_test1.md_badge.svg)](https://gist.github.com/ebekker/9158b8c9a9999270ef482faae6f4a742#pester-tests-report_Marketplace_GHAction_test1.md)
+* [![Example Pester Tests Badge](https://gist.github.com/ebekker/5e97f7385f1c7812118d39306b938cd0/raw/pester-tests-report_Marketplace_GHAction_test2.md_badge.svg)](https://gist.github.com/ebekker/5e97f7385f1c7812118d39306b938cd0#pester-tests-report_Marketplace_GHAction_test2.md)
+* [![Example Pester Tests Badge](https://gist.github.com/ebekker/dff5ae43943226d800cd1ee891dc889b/raw/pester-tests-report_GHAction_test1.md_badge.svg)](https://gist.github.com/ebekker/dff5ae43943226d800cd1ee891dc889b)
 
 And here are some samples of the actual generated reports:
 

--- a/action.ps1
+++ b/action.ps1
@@ -421,7 +421,7 @@ if ($test_results_path) {
     if ($inputs.gist_name -and $inputs.gist_token) {
         if ($inputs.coverage_gist) {
             $coverageReportData = [System.IO.File]::ReadAllText($coverage_report_path)
-            Publish-ToGist -ReportData $reportData -CoverageData $coverageReportData
+            Publish-ToGist -ReportData $reportData -CoverageData $coverageSummaryData
         } else {
             Publish-ToGist -ReportData $reportData
         }

--- a/action.ps1
+++ b/action.ps1
@@ -228,7 +228,7 @@ function Build-CoverageReport {
         $script:coverage_report_title = $report_name
     }
 
-    $script:coverage_summary_path = Join-Path $test_results_dir summary.txt
+    $script:coverage_summary_path = Join-Path $test_results_dir Summary.txt
     $script:coverage_report_path = Join-Path $test_results_dir index.html
     $script:coverage_badge_path = Join-Path $test_results_dir badge_combined.svg
     dotnet tool install -g dotnet-reportgenerator-globaltool
@@ -370,11 +370,11 @@ function Publish-ToGist {
         }
     }
     if ($coverageData) {
-        $gistFile."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage.html" = @{ content = $coverageData }
+        $gistFiles."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage.html" = @{ content = $coverageData }
     }
     if ($input.coverage_gist_badge) {
         $coverageBadgeData = [System.IO.File]::ReadAllText($coverage_badge_path)
-        $gistFile."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage_badge.svg" = @{ content = $coverageBadgeData }
+        $gistFiles."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage_badge.svg" = @{ content = $coverageBadgeData }
     }
 
     if (-not $reportGist) {

--- a/action.ps1
+++ b/action.ps1
@@ -118,8 +118,12 @@ else {
     if ($coverage_paths) {
         Write-ActionInfo "  * coverage_paths:"
         writeListInput $coverage_paths
+        $coverageFiles = @()
+        foreach ($path in $coverage_paths) {
+            $coverageFiles +=  Get-ChildItem $Path -Recurse -Include @("*.ps1","*.psm1") -Exclude "*.Tests.ps1"
+        }
         $pesterConfig.CodeCoverage.Enabled = $true
-        $pesterConfig.CodeCoverage.Path = $coverage_paths
+        $pesterConfig.CodeCoverage.Path = $coverageFiles
         $coverage_results_path = Join-Path $test_results_dir coverage.xml
         $pesterConfig.CodeCoverage.OutputPath = $coverage_results_path
     }

--- a/action.ps1
+++ b/action.ps1
@@ -228,8 +228,8 @@ function Build-CoverageReport {
         $script:coverage_report_title = $report_name
     }
 
-    $script:coverage_report_path = Join-Path $test_results_dir coverage.html
-    $script:coverage_badge_path = Join-Path $test_results_dir coverage.svg
+    $script:coverage_report_path = Join-Path $test_results_dir index.html
+    $script:coverage_badge_path = Join-Path $test_results_dir badge_combined.svg
     dotnet tool install -g dotnet-reportgenerator-globaltool
     reportgenerator -reports:"$script:coverage_results_path" -targetdir:"$test_results_dir" -reporttypes:"HtmlInline;Badges" -title:"$coverage_report_title"
 }

--- a/action.ps1
+++ b/action.ps1
@@ -228,6 +228,7 @@ function Build-CoverageReport {
         $script:coverage_report_title = $report_name
     }
 
+    $script:coverage_summary_path = Join-Path $test_results_dir summary.txt
     $script:coverage_report_path = Join-Path $test_results_dir index.html
     $script:coverage_badge_path = Join-Path $test_results_dir badge_combined.svg
     dotnet tool install -g dotnet-reportgenerator-globaltool
@@ -409,19 +410,19 @@ if ($test_results_path) {
 
         Build-CoverageReport
 
-        $coverageData = [System.IO.File]::ReadAllText($coverage_report_path)
+        $coverageSummaryData = [System.IO.File]::ReadAllText($coverage_summary_path)
     }
 
     if ($inputs.skip_check_run -ne $true) {
         Publish-ToCheckRun -ReportData $reportData -ReportName $report_name -ReportTitle $report_title
         if ($coverage_results_path) {
-            Publish-ToCheckRun -ReportData $coverageData -ReportName $coverage_report_name -ReportTitle $coverage_report_title
+            Publish-ToCheckRun -ReportData $coverageSummaryData -ReportName $coverage_report_name -ReportTitle $coverage_report_title
         }
     }
     if ($inputs.gist_name -and $inputs.gist_token) {
         if ($inputs.coverage_gist) {
-            $coverageData = [System.IO.File]::ReadAllText($coverage_report_path)
-            Publish-ToGist -ReportData $reportData -CoverageData $coverageData
+            $coverageReportData = [System.IO.File]::ReadAllText($coverage_report_path)
+            Publish-ToGist -ReportData $reportData -CoverageData $coverageReportData
         } else {
             Publish-ToGist -ReportData $reportData
         }

--- a/action.ps1
+++ b/action.ps1
@@ -282,6 +282,7 @@ function Publish-ToCheckRun {
             text    = $reportData
         }
     }
+    Write-ActionInfo "WR Body $($bdy | ConvertTo-Json)"
     Invoke-WebRequest -Headers $hdr $url -Method Post -Body ($bdy | ConvertTo-Json)
 }
 

--- a/action.ps1
+++ b/action.ps1
@@ -128,6 +128,8 @@ else {
         $pesterConfig.CodeCoverage.Path = $coverageFiles
         $coverage_results_path = Join-Path $test_results_dir coverage.xml
         $pesterConfig.CodeCoverage.OutputPath = $coverage_results_path
+    }
+
     if ($inputs.tests_fail_step) {
         Write-ActionInfo "  * tests_fail_step: true"
     }

--- a/action.ps1
+++ b/action.ps1
@@ -382,7 +382,7 @@ function Publish-ToGist {
         }
     }
     if ($coverageData) {
-        $gistFiles."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage.html" = @{ content = $coverageData }
+        $gistFiles."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage.txt" = @{ content = $coverageData }
     }
     if ($inputs.coverage_gist_badge) {
         $coverageBadgeData = [System.IO.File]::ReadAllText($coverage_badge_path)

--- a/action.ps1
+++ b/action.ps1
@@ -290,7 +290,6 @@ function Publish-ToCheckRun {
             text    = $reportData
         }
     }
-    Write-ActionInfo "WR Body $($bdy | ConvertTo-Json)"
     Invoke-WebRequest -Headers $hdr $url -Method Post -Body ($bdy | ConvertTo-Json)
 }
 
@@ -376,7 +375,7 @@ function Publish-ToGist {
         $coverageBadgeData = [System.IO.File]::ReadAllText($coverage_badge_path)
         $gistFiles."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage_badge.svg" = @{ content = $coverageBadgeData }
     }
-
+    Write-ActionInfo "Gist JSON $($gistFiles | ConvertTo-Json)"
     if (-not $reportGist) {
         Write-ActionInfo "Creating initial Tests Report Gist"
         $createGistResp = Invoke-WebRequest -Headers $apiHeaders -Uri $gistsApiUrl -Method Post -Body (@{

--- a/action.ps1
+++ b/action.ps1
@@ -231,7 +231,7 @@ function Build-CoverageReport {
     $script:coverage_report_path = Join-Path $test_results_dir coverage.html
     $script:coverage_badge_path = Join-Path $test_results_dir coverage.svg
     dotnet tool install -g dotnet-reportgenerator-globaltool
-    reportgenerator -reports:$script:coverage_results_path -targetdir:$test_results_dir -reporttypes:HtmlInline;Badges -title:$coverage_report_title
+    reportgenerator -reports:"$script:coverage_results_path" -targetdir:"$test_results_dir" -reporttypes:"HtmlInline;Badges" -title:"$coverage_report_title"
 }
 
 function Publish-ToCheckRun {
@@ -407,7 +407,7 @@ if ($test_results_path) {
     if ($inputs.skip_check_run -ne $true) {
         Publish-ToCheckRun -ReportData $reportData -ReportName $report_name -ReportTitle $report_title
         if ($coverage_results_path) {
-            Publish-ToCheckRun -ReportData $coverageData -ReportName $coverage_report_name -ReportTitle $coverge_report_title
+            Publish-ToCheckRun -ReportData $coverageData -ReportName $coverage_report_name -ReportTitle $coverage_report_title
         }
     }
     if ($inputs.gist_name -and $inputs.gist_token) {

--- a/action.ps1
+++ b/action.ps1
@@ -231,7 +231,14 @@ function Build-CoverageReport {
     $script:coverage_report_path = Join-Path $test_results_dir index.html
     $script:coverage_badge_path = Join-Path $test_results_dir badge_combined.svg
     dotnet tool install -g dotnet-reportgenerator-globaltool
-    reportgenerator -reports:"$script:coverage_results_path" -targetdir:"$test_results_dir" -reporttypes:"HtmlInline;Badges" -title:"$coverage_report_title"
+    $sourceDirs = ""
+    foreach ($path in $coverage_paths) {
+        if ($sourceDirs) {
+            $sourceDirs += ";"
+        }
+        $sourceDirs += Split-Path $path
+    }
+    reportgenerator -reports:"$script:coverage_results_path" -targetdir:"$test_results_dir" -reporttypes:"HtmlInline_AzurePipelines_Dark;Badges;TextSummary" -title:"$coverage_report_title" -sourcedirs:"$SourceDirs"
 }
 
 function Publish-ToCheckRun {

--- a/action.ps1
+++ b/action.ps1
@@ -416,7 +416,7 @@ if ($test_results_path) {
     if ($inputs.skip_check_run -ne $true) {
         Publish-ToCheckRun -ReportData $reportData -ReportName $report_name -ReportTitle $report_title
         if ($coverage_results_path) {
-            Publish-ToCheckRun -ReportData $coverageReportData -ReportName $coverage_report_name -ReportTitle $coverage_report_title
+            Publish-ToCheckRun -ReportData $coverageSummaryData -ReportName $coverage_report_name -ReportTitle $coverage_report_title
         }
     }
     if ($inputs.gist_name -and $inputs.gist_token) {

--- a/action.ps1
+++ b/action.ps1
@@ -371,7 +371,7 @@ function Publish-ToGist {
     if ($coverageData) {
         $gistFiles."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage.html" = @{ content = $coverageData }
     }
-    if ($input.coverage_gist_badge) {
+    if ($inputs.coverage_gist_badge) {
         $coverageBadgeData = [System.IO.File]::ReadAllText($coverage_badge_path)
         $gistFiles."$([io.path]::GetFileNameWithoutExtension($reportGistName))_Coverage_badge.svg" = @{ content = $coverageBadgeData }
     }

--- a/action.ps1
+++ b/action.ps1
@@ -229,7 +229,7 @@ function Build-CoverageReport {
     }
 
     $script:coverage_summary_path = Join-Path $test_results_dir Summary.txt
-    $script:coverage_report_path = Join-Path $test_results_dir Summary.html
+    $script:coverage_report_path = Join-Path $test_results_dir summary.html
     $script:coverage_badge_path = Join-Path $test_results_dir badge_shieldsio_linecoverage_lightgrey.svg
     dotnet tool install -g dotnet-reportgenerator-globaltool
     $sourceDirs = ""
@@ -307,7 +307,7 @@ function Publish-ToGist {
 
     $gistsApiUrl = "https://api.github.com/gists"
     $apiHeaders = @{
-        Accept        = "application/vnd.github.v2+json"
+        Accept        = "application/vnd.github.v3+json"
         Authorization = "token $gist_token"
     }
 

--- a/action.yml
+++ b/action.yml
@@ -160,11 +160,13 @@ inputs:
       `gist_name`.
     required: false
 
-  coverage_gist_badge:
+  coverage_gist_badge_label:
     description: |
-      If true, render a coverage badge and add it to the gist specified in
-      `gist_name`.
+      If specified, the Test Report Gist will also include an adjacent
+      badge rendered with the percentage of the associated Coverage Report 
+      and label content of this input.
     required: false
+
   tests_fail_step:
     description: |
       If true, will cause the step to fail if one or more tests fails.

--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,40 @@ inputs:
       You can control which account is used to actually store the state by
       generating a token associated with the target account.
 
+  coverage_paths:
+    description: |
+      Comma-separated list of one or more files or directories
+      to scan for code coverage, relative to the root of the project. You 
+      must have run `actions/setup-dotnet` prior to running this action 
+      if you wish to use code coverage.
+    required: false
+
+  coverage_report_name:
+    description: |
+      The name of the code coverage report object that will be attached 
+      to the Workflow Run.  Defaults to the name 
+      `COVERAGE_RESULTS_<datetime>` where `<datetime>` is in the form 
+      `yyyyMMdd_hhmmss`.
+    required: false
+
+  coverage_report_title:
+    description: |
+      The title of the code coverage report that will be embedded in the 
+      report itself, which defaults to the same as the 
+      `code_coverage_report_name` input.
+    required: false
+
+  coverage_gist:
+    description: |
+      If true, will attach the coverage results to the gist specified in 
+      `gist_name`.
+    required: false
+
+  coverage_gist_badge:
+    description: |
+      If true, render a coverage badge and add it to the gist specified in
+      `gist_name`.
+    required: false
 
 ## Here you describe your *formal* outputs.
 outputs:
@@ -175,6 +209,9 @@ outputs:
 
   failed_count:
     description: Total number of tests failed.
+
+  coverage_results_path:
+    description: Path to the code coverage results file.
 
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -134,10 +134,9 @@ inputs:
 
   coverage_paths:
     description: |
-      Comma-separated list of one or more files or directories
-      to scan for code coverage, relative to the root of the project. You 
-      must have run `actions/setup-dotnet` prior to running this action 
-      if you wish to use code coverage.
+      Comma-separated list of one or more directories to scan for code 
+      coverage, relative to the root of the project. Will include all .ps1
+      and .psm1 files under these directories recursively.
     required: false
 
   coverage_report_name:

--- a/action.yml
+++ b/action.yml
@@ -210,7 +210,8 @@ outputs:
     description: Total number of tests failed.
 
   coverage_results_path:
-    description: Path to the code coverage results file.
+    description: |
+      Path to the code coverage results file in JaCoCo XML format.
 
 
 branding:

--- a/jacoco-report/embedmissedlines.ps1
+++ b/jacoco-report/embedmissedlines.ps1
@@ -1,0 +1,37 @@
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$mdFile
+)
+
+$mdData = Get-Content -Path $mdFile
+
+$outputData = @()
+foreach ($line in $mdData) {
+    if ($line -like "- Line #*") {
+        $linePrefix = $line.Split("|")[0]
+        $lineNumber = $linePrefix.Split("#")[1]
+        $arrayLineNumber = $lineNumber - 1
+
+        $filePath = $line.Split("|")[1]
+        if ($IsWindows -or $PSVersionTable.PSVersion.Major -le 5) {
+            $filePath = $filePath.Replace("/","\")
+        }
+        $workspaceFiles = Get-ChildItem -Path "$env:GITHUB_WORKSPACE" -Recurse -File
+        $resolvedFilePath = $workspaceFiles | Where-Object {$_.FullName -like "*$filePath"}
+        $fileContents = Get-Content -Path $resolvedFilePath
+        $missedLine = $fileContents[$arrayLineNumber]
+
+        $outputData += $linePrefix
+        $outputData += "``````"
+        $outputData += $missedLine
+        $outputData += "``````"
+
+    }
+    else {
+        $outputData += $line
+    }
+}
+
+Set-Content -Value $outputData -Path $mdFile

--- a/jacoco-report/example.jacoco.md
+++ b/jacoco-report/example.jacoco.md
@@ -1,0 +1,98 @@
+
+# Coverage Report: Pester (04/16/2021 11:51:47)
+
+* Pester (04/16/2021 11:51:47)
+
+Outcome: 98.43% Coverage
+         | Lines Covered: 191
+         | Lines Missed: 3
+
+## Details:
+
+    
+### src
+
+<details>
+    <summary>
+:x: ChangelogManagement.psm1
+    </summary>
+
+        
+#### Lines Missed:
+        
+- Line #4
+```
+        . $PrivateFile.FullName
+```
+</details>
+
+    
+### src/public
+
+<details>
+    <summary>
+:heavy_check_mark: Add-ChangelogData.ps1
+    </summary>
+
+        
+#### All Lines Covered!
+        
+</details>
+
+    
+
+<details>
+    <summary>
+:heavy_check_mark: ConvertFrom-Changelog.ps1
+    </summary>
+
+        
+#### All Lines Covered!
+        
+</details>
+
+    
+
+<details>
+    <summary>
+:heavy_check_mark: Get-ChangelogData.ps1
+    </summary>
+
+        
+#### All Lines Covered!
+        
+</details>
+
+    
+
+<details>
+    <summary>
+:heavy_check_mark: New-Changelog.ps1
+    </summary>
+
+        
+#### All Lines Covered!
+        
+</details>
+
+    
+
+<details>
+    <summary>
+:x: Update-Changelog.ps1
+    </summary>
+
+        
+#### Lines Missed:
+        
+- Line #79
+```
+            throw "You must be running in GitHub Actions to use GitHub LinkMode"
+```
+- Line #89
+```
+            throw "You must be running in Azure Pipelines to use AzureDevOps LinkMode"
+```
+</details>
+
+    

--- a/jacoco-report/example.jacoco.xml
+++ b/jacoco-report/example.jacoco.xml
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"><report name="Pester (04/16/2021 11:51:47)">
+    <sessioninfo id="this" start="1618573899222" dump="1618573907682" />
+    <package name="src">
+        <class name="src/ChangelogManagement" sourcefilename="ChangelogManagement.psm1">
+            <method name="&lt;script&gt;" desc="()" line="1">
+                <counter type="INSTRUCTION" missed="1" covered="9" />
+                <counter type="LINE" missed="1" covered="9" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <counter type="INSTRUCTION" missed="1" covered="9" />
+            <counter type="LINE" missed="1" covered="9" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </class>
+        <sourcefile name="ChangelogManagement.psm1">
+            <line nr="1" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="2" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="3" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="4" mi="1" ci="0" mb="0" cb="0" />
+            <line nr="8" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="9" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="10" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="11" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="12" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="15" mi="0" ci="1" mb="0" cb="0" />
+            <counter type="INSTRUCTION" missed="1" covered="9" />
+            <counter type="LINE" missed="1" covered="9" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </sourcefile>
+        <counter type="INSTRUCTION" missed="1" covered="9" />
+        <counter type="LINE" missed="1" covered="9" />
+        <counter type="METHOD" missed="0" covered="1" />
+        <counter type="CLASS" missed="0" covered="1" />
+    </package>
+    <package name="src/public">
+        <class name="src/public/Add-ChangelogData" sourcefilename="Add-ChangelogData.ps1">
+            <method name="Add-ChangelogData" desc="()" line="31">
+                <counter type="INSTRUCTION" missed="0" covered="30" />
+                <counter type="LINE" missed="0" covered="28" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <counter type="INSTRUCTION" missed="0" covered="30" />
+            <counter type="LINE" missed="0" covered="28" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </class>
+        <class name="src/public/ConvertFrom-Changelog" sourcefilename="ConvertFrom-Changelog.ps1">
+            <method name="ConvertFrom-Changelog" desc="()" line="32">
+                <counter type="INSTRUCTION" missed="0" covered="26" />
+                <counter type="LINE" missed="0" covered="24" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <counter type="INSTRUCTION" missed="0" covered="26" />
+            <counter type="LINE" missed="0" covered="24" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </class>
+        <class name="src/public/Get-ChangelogData" sourcefilename="Get-ChangelogData.ps1">
+            <method name="Get-ChangelogData" desc="()" line="26">
+                <counter type="INSTRUCTION" missed="0" covered="88" />
+                <counter type="LINE" missed="0" covered="70" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <counter type="INSTRUCTION" missed="0" covered="88" />
+            <counter type="LINE" missed="0" covered="70" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </class>
+        <class name="src/public/New-Changelog" sourcefilename="New-Changelog.ps1">
+            <method name="New-Changelog" desc="()" line="39">
+                <counter type="INSTRUCTION" missed="0" covered="11" />
+                <counter type="LINE" missed="0" covered="11" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <counter type="INSTRUCTION" missed="0" covered="11" />
+            <counter type="LINE" missed="0" covered="11" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </class>
+        <class name="src/public/Update-Changelog" sourcefilename="Update-Changelog.ps1">
+            <method name="Update-Changelog" desc="()" line="37">
+                <counter type="INSTRUCTION" missed="2" covered="64" />
+                <counter type="LINE" missed="2" covered="49" />
+                <counter type="METHOD" missed="0" covered="1" />
+            </method>
+            <counter type="INSTRUCTION" missed="2" covered="64" />
+            <counter type="LINE" missed="2" covered="49" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </class>
+        <sourcefile name="Add-ChangelogData.ps1">
+            <line nr="31" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="51" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="52" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="53" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="56" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="59" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="60" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="62" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="63" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="64" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="65" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="66" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="67" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="68" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="69" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="70" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="72" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="73" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="74" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="76" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="77" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="78" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="81" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="82" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="85" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="86" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="88" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="90" mi="0" ci="1" mb="0" cb="0" />
+            <counter type="INSTRUCTION" missed="0" covered="30" />
+            <counter type="LINE" missed="0" covered="28" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </sourcefile>
+        <sourcefile name="ConvertFrom-Changelog.ps1">
+            <line nr="32" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="53" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="55" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="56" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="57" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="58" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="59" mi="0" ci="3" mb="0" cb="0" />
+            <line nr="62" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="65" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="66" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="67" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="69" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="71" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="72" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="73" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="75" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="77" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="78" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="79" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="82" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="83" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="84" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="85" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="88" mi="0" ci="1" mb="0" cb="0" />
+            <counter type="INSTRUCTION" missed="0" covered="26" />
+            <counter type="LINE" missed="0" covered="24" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </sourcefile>
+        <sourcefile name="Get-ChangelogData.ps1">
+            <line nr="26" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="31" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="32" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="33" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="35" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="38" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="39" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="41" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="42" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="43" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="44" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="45" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="46" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="47" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="51" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="52" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="53" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="54" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="55" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="56" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="61" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="62" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="63" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="64" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="68" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="69" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="70" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="72" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="76" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="77" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="78" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="80" mi="0" ci="5" mb="0" cb="0" />
+            <line nr="81" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="84" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="85" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="86" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="87" mi="0" ci="3" mb="0" cb="0" />
+            <line nr="88" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="89" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="90" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="91" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="92" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="93" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="94" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="100" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="101" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="102" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="103" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="105" mi="0" ci="5" mb="0" cb="0" />
+            <line nr="106" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="110" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="111" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="112" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="113" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="114" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="115" mi="0" ci="3" mb="0" cb="0" />
+            <line nr="116" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="117" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="118" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="119" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="120" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="121" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="122" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="129" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="130" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="132" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="135" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="136" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="138" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="141" mi="0" ci="1" mb="0" cb="0" />
+            <counter type="INSTRUCTION" missed="0" covered="88" />
+            <counter type="LINE" missed="0" covered="70" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </sourcefile>
+        <sourcefile name="New-Changelog.ps1">
+            <line nr="39" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="41" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="43" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="44" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="45" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="46" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="47" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="48" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="50" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="51" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="53" mi="0" ci="1" mb="0" cb="0" />
+            <counter type="INSTRUCTION" missed="0" covered="11" />
+            <counter type="LINE" missed="0" covered="11" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </sourcefile>
+        <sourcefile name="Update-Changelog.ps1">
+            <line nr="37" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="65" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="66" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="67" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="70" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="73" mi="0" ci="3" mb="0" cb="0" />
+            <line nr="74" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="77" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="78" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="79" mi="1" ci="0" mb="0" cb="0" />
+            <line nr="81" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="82" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="83" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="84" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="87" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="88" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="89" mi="1" ci="0" mb="0" cb="0" />
+            <line nr="91" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="92" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="93" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="94" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="95" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="99" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="107" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="109" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="110" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="114" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="115" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="118" mi="0" ci="4" mb="0" cb="0" />
+            <line nr="119" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="120" mi="0" ci="3" mb="0" cb="0" />
+            <line nr="121" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="122" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="125" mi="0" ci="3" mb="0" cb="0" />
+            <line nr="126" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="129" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="130" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="131" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="133" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="137" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="140" mi="0" ci="2" mb="0" cb="0" />
+            <line nr="143" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="144" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="148" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="149" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="150" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="151" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="152" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="153" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="156" mi="0" ci="1" mb="0" cb="0" />
+            <line nr="158" mi="0" ci="1" mb="0" cb="0" />
+            <counter type="INSTRUCTION" missed="2" covered="64" />
+            <counter type="LINE" missed="2" covered="49" />
+            <counter type="METHOD" missed="0" covered="1" />
+            <counter type="CLASS" missed="0" covered="1" />
+        </sourcefile>
+        <counter type="INSTRUCTION" missed="2" covered="219" />
+        <counter type="LINE" missed="2" covered="182" />
+        <counter type="METHOD" missed="0" covered="5" />
+        <counter type="CLASS" missed="0" covered="5" />
+    </package>
+    <counter type="INSTRUCTION" missed="3" covered="228" />
+    <counter type="LINE" missed="3" covered="191" />
+    <counter type="METHOD" missed="0" covered="6" />
+    <counter type="CLASS" missed="0" covered="6" />
+</report>

--- a/jacoco-report/jacocoxml2md.ps1
+++ b/jacoco-report/jacocoxml2md.ps1
@@ -1,0 +1,83 @@
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$xmlFile,
+    [string]$mdFile=$null,
+    [string]$xslFile=$null,
+    [hashtable]$xslParams=$null
+)
+
+if ($xmlFile -notmatch '^[/\\]') {
+    $xmlFile = [System.IO.Path]::Combine($PWD, $xmlFile)
+    Write-Verbose "Resolving XML file relative to current directory: $xmlFile"
+}
+
+if (-not $mdFile) {
+    $mdFile = $xmlFile
+    if ([System.IO.Path]::GetExtension($xmlFile) -ieq '.xml') {
+        $mdFile = $xmlFile -ireplace '.xml$',''
+    }
+    $mdFile += '.md'
+    Write-Verbose "Resolving default MD file: $mdFile"
+}
+elseif ($mdFile -notmatch '^[/\\]') {
+    $mdFile = [System.IO.Path]::Combine($PWD, $mdFile)
+    Write-Verbose "Resolving MD file relative to current directory: $mdFile"
+}
+
+if (-not $xslFile) {
+    $xslFile = "$PSScriptRoot/jacocoxml2md.xsl"
+    Write-Verbose "Resolving default XSL file: $xslFile"
+}
+elseif ($xslFile -notmatch '^[/\\]') {
+    $xslFile = [System.IO.Path]::Combine($PWD, $xslFile)
+    Write-Verbose "Resolving XSL file relative to current directory: $xslFile"
+
+}
+
+class NUnitXML {
+    [double]DiffSeconds([datetime]$from, [datetime]$till) {
+        return ($till - $from).TotalSeconds
+    }
+}
+
+
+if (-not $script:xslt) {
+    $script:urlr = [System.Xml.XmlUrlResolver]::new()
+    $script:opts = [System.Xml.Xsl.XsltSettings]::new()
+    #$script:opts.EnableScript = $true
+    $script:xslt = [System.Xml.Xsl.XslCompiledTransform]::new()
+    try {
+        $script:xslt.Load($xslFile, $script:opts, $script:urlr)
+    }
+    catch {
+        Write-Error $Error[0]
+        return
+    }
+    Write-Verbose "Loaded XSL transformer"
+}
+
+$script:list = [System.Xml.Xsl.XsltArgumentList]::new()
+$script:list.AddExtensionObject("urn:nuxml", [NUnitXML]::new())
+if ($xslParams) {
+    foreach ($xp in $xslParams.GetEnumerator()) {
+        $script:list.AddParam($xp.Key, [string]::Empty, $xp.Value)
+    }
+}
+
+$script:wrtr = [System.IO.StreamWriter]::new($mdFile)
+try {
+    Write-Verbose "Transforming XML to MD"
+    $script:readerSettings = [System.Xml.XmlReaderSettings]::new()
+    $script:readerSettings.DtdProcessing = "Parse"
+    $script:reader = [System.Xml.XmlReader]::Create($xmlFile,$script:readerSettings)
+
+    $script:xslt.Transform(
+        [System.Xml.XmlReader]$script:reader,
+        [System.Xml.Xsl.XsltArgumentList]$script:list,
+        [System.IO.TextWriter]$script:wrtr)
+}
+finally {
+    $script:wrtr.Dispose()
+}

--- a/jacoco-report/jacocoxml2md.xsl
+++ b/jacoco-report/jacocoxml2md.xsl
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:ms="urn:schemas-microsoft-com:xslt"
+                xmlns:dt="urn:schemas-microsoft-com:datatypes"
+                >
+
+    <xsl:output method="text"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:param name="reportTitle">
+        <xsl:value-of select="/report/@name" />
+    </xsl:param>
+
+<!--https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md-->
+<!--
+    :radio_button:
+    :x:
+    
+    :white_circle:
+    :grey_question:
+-->
+    <xsl:template match="/">
+# Coverage Report: <xsl:value-of select="$reportTitle" />
+
+* <xsl:value-of select="/report/@name" />
+
+<xsl:variable name="overallPercentage">
+    <xsl:choose>
+        <xsl:when test="/report/counter[@type='LINE']/@missed = 0">100</xsl:when>
+        <xsl:otherwise><xsl:value-of select="format-number((100 - ((/report/counter[@type='LINE']/@missed div /report/counter[@type='LINE']/@covered) * 100)),'#.##')" /></xsl:otherwise>
+    </xsl:choose>
+</xsl:variable>
+
+Outcome: <xsl:value-of select="$overallPercentage" />% Coverage
+         | Lines Covered: <xsl:value-of select="/report/counter[@type='LINE']/@covered" />
+         | Lines Missed: <xsl:value-of select="/report/counter[@type='LINE']/@missed" />
+
+## Details:
+
+    <xsl:apply-templates select="/report/package" />
+    </xsl:template>
+
+    <xsl:template match="package">
+### <xsl:value-of select="@name" />
+
+        <xsl:apply-templates select="sourcefile">
+        </xsl:apply-templates>
+    </xsl:template>
+
+    <xsl:template match="sourcefile">
+        <xsl:variable name="linesMissed" select="counter[@type='LINE']/@missed" />
+        <xsl:variable name="testOutcomeIcon">
+            <xsl:choose>
+                <xsl:when test="$linesMissed = '0'">:heavy_check_mark:</xsl:when>
+                <xsl:otherwise>:x:</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+&lt;details&gt;
+    &lt;summary&gt;
+<xsl:value-of select="$testOutcomeIcon" />
+<xsl:text> </xsl:text>
+<xsl:value-of select="@name" />
+    &lt;/summary&gt;
+
+        <xsl:if test="$linesMissed != 0">
+#### Lines Missed:
+        </xsl:if>
+
+        <xsl:if test="$linesMissed = 0">
+#### All Lines Covered!
+        </xsl:if>
+
+        <xsl:apply-templates select="line[@mi='1']" />
+&lt;/details&gt;
+
+    </xsl:template>
+
+    <xsl:template match="line[@mi='1']">
+        <xsl:variable name="fileName" select="../@name" />
+- Line #<xsl:apply-templates select="@nr" />|<xsl:value-of select="../../@name" />/<xsl:value-of select="$fileName" />
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Okay, I have functional code coverage added. It uses the same functionality as the primary test report vis-a-vis posting the results via check run and badge and test results to the gist.

I'm happy with the code coverage testing functionality itself but I'm less happy with the report generated. I used https://github.com/danielpalme/ReportGenerator to convert from the JaCoCo to a text format and generate a code coverage badge. Unfortunately, it doesn't have markdown output (couldn't really find anything that would do JaCoCo to MD), and the HTML outputs it generated were too big for check runs or seemingly Gists.

The best way to generate the report would probably be doing an XSL based translation to Markdown like you are doing for the test reports, but I'm afraid that's outside of what I know how to do and I don't have time to learn at this moment.

Perhaps this could just be regarded as a first pass at code coverage with better report formatting coming in the future?

Here's an example of the outputs:

https://github.com/natescherer/PoshEmail/actions/runs/733609157
https://gist.github.com/natescherer/797ca586d176e0af436182c772e35c24

I would welcome your thoughts and comments.