### PR TITLE
Add check for workflow_dispatch to Publish-ToCheckRun

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -259,48 +259,52 @@ function Publish-ToCheckRun {
         [string]$reportTitle
     )
 
-    Write-ActionInfo "Publishing Report to GH Workflow"
+    if ($env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
+        Write-Host "::notice title=Check Run Publishing Skipped::Check run publishing has been skipped as it is not possible to attach check runs to workflows triggered with 'workflow_dispatch'."
+    } else {
+        Write-ActionInfo "Publishing Report to GH Workflow"
 
-    $ghToken = $inputs.github_token
-    $ctx = Get-ActionContext
-    $repo = Get-ActionRepo
-    $repoFullName = "$($repo.Owner)/$($repo.Repo)"
+        $ghToken = $inputs.github_token
+        $ctx = Get-ActionContext
+        $repo = Get-ActionRepo
+        $repoFullName = "$($repo.Owner)/$($repo.Repo)"
 
-    Write-ActionInfo "Resolving REF"
-    $ref = $ctx.Sha
-    if ($ctx.EventName -eq 'pull_request') {
-        Write-ActionInfo "Resolving PR REF"
-        $ref = $ctx.Payload.pull_request.head.sha
+        Write-ActionInfo "Resolving REF"
+        $ref = $ctx.Sha
+        if ($ctx.EventName -eq 'pull_request') {
+            Write-ActionInfo "Resolving PR REF"
+            $ref = $ctx.Payload.pull_request.head.sha
+            if (-not $ref) {
+                Write-ActionInfo "Resolving PR REF as AFTER"
+                $ref = $ctx.Payload.after
+            }
+        }
         if (-not $ref) {
-            Write-ActionInfo "Resolving PR REF as AFTER"
-            $ref = $ctx.Payload.after
+            Write-ActionError "Failed to resolve REF"
+            exit 1
         }
-    }
-    if (-not $ref) {
-        Write-ActionError "Failed to resolve REF"
-        exit 1
-    }
-    Write-ActionInfo "Resolved REF as $ref"
-    Write-ActionInfo "Resolve Repo Full Name as $repoFullName"
+        Write-ActionInfo "Resolved REF as $ref"
+        Write-ActionInfo "Resolve Repo Full Name as $repoFullName"
 
-    Write-ActionInfo "Adding Check Run"
-    $url = "https://api.github.com/repos/$repoFullName/check-runs"
-    $hdr = @{
-        Accept = 'application/vnd.github.antiope-preview+json'
-        Authorization = "token $ghToken"
-    }
-    $bdy = @{
-        name       = $reportName
-        head_sha   = $ref
-        status     = 'completed'
-        conclusion = 'neutral'
-        output     = @{
-            title   = $reportTitle
-            summary = "This run completed at ``$([datetime]::Now)``"
-            text    = $reportData
+        Write-ActionInfo "Adding Check Run"
+        $url = "https://api.github.com/repos/$repoFullName/check-runs"
+        $hdr = @{
+            Accept = 'application/vnd.github.antiope-preview+json'
+            Authorization = "token $ghToken"
         }
+        $bdy = @{
+            name       = $reportName
+            head_sha   = $ref
+            status     = 'completed'
+            conclusion = 'neutral'
+            output     = @{
+                title   = $reportTitle
+                summary = "This run completed at ``$([datetime]::Now)``"
+                text    = $reportData
+            }
+        }
+        Invoke-WebRequest -Headers $hdr $url -Method Post -Body ($bdy | ConvertTo-Json)
     }
-    Invoke-WebRequest -Headers $hdr $url -Method Post -Body ($bdy | ConvertTo-Json)
 }
 
 function Publish-ToGist {


### PR DESCRIPTION
Hello! I discovered in my own testing that when you call a workflow via workflow_dispatch and have publishing to check runs on, the check runs don't attach to that workflow, but instead attach to the first workflow run with the ref. After looking at the checks API, there doesn't appear to be a way to get around this, so I made this change that will skip the attempt to post and put up a notice if $env:GITHUB_EVENT_NAME -eq "workflow_dispatch".