### PR TITLE
Update node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -228,5 +228,5 @@ branding:
 ## Even though the Action logic may be implemented
 ## in PWSH, we still need a NodeJS entry point
 runs:
-  using: node12
+  using: node16
   main: _init/index.js


### PR DESCRIPTION
Node 12 is deprecated, bumping to node 16.
This addresses issue #24 